### PR TITLE
Fixed bug causing some upnp devices to respond with an 412 error code on subscription renewal

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,6 +365,9 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
           });
         });
 
+        // Send 200 response to UPnP device
+        res.statusCode = 200;
+        res.end()
       }));
 
     });


### PR DESCRIPTION
I've got an Heos UPnP enabled speaker which would send an error on subscription renewal. This was caused by not responding to incoming webhook http request. I fixed it by ending every incoming webhook request with an 200 response.